### PR TITLE
Update to use OOjs UI

### DIFF
--- a/css/ext.oredict.import.css
+++ b/css/ext.oredict.import.css
@@ -1,0 +1,14 @@
+.oredict-import-update-hint-label {
+    font-size: x-small;
+    padding-top: 0.5em;
+    color: #666666;
+}
+
+.oredict-import-textarea textarea {
+    width: 150%;
+}
+
+.oredict-import-update {
+    padding-top: 10px;
+    vertical-align: bottom;
+}

--- a/css/ext.oredict.manager.css
+++ b/css/ext.oredict.manager.css
@@ -1,0 +1,3 @@
+.entry-manager-wrapper, .entry-manager-filter-wrapper {
+    width: 50%;
+}

--- a/extension.json
+++ b/extension.json
@@ -59,7 +59,8 @@
 			"styles": "css/ext.oredict.list.css"
 		},
 		"ext.oredict.manager": {
-			"scripts": "js/ext.oredict.manager.js"
+			"scripts": "js/ext.oredict.manager.js",
+			"styles": "css/ext.oredict.manager.css"
 		}
 	},
 	"ResourceFileModulePaths": {

--- a/extension.json
+++ b/extension.json
@@ -61,6 +61,9 @@
 		"ext.oredict.manager": {
 			"scripts": "js/ext.oredict.manager.js",
 			"styles": "css/ext.oredict.manager.css"
+		},
+		"ext.oredict.import": {
+			"styles": "css/ext.oredict.import.css"
 		}
 	},
 	"ResourceFileModulePaths": {

--- a/special/ImportOreDict.php
+++ b/special/ImportOreDict.php
@@ -34,6 +34,8 @@ class ImportOreDict extends SpecialPage {
 		$this->checkPermissions();
 
 		$out = $this->getOutput();
+		$out->enableOOUI();
+		$out->addModules('ext.oredict.import');
 
 		$this->setHeaders();
 		$this->outputHeader();
@@ -157,38 +159,76 @@ class ImportOreDict extends SpecialPage {
 
 	private function buildForm() {
 		global $wgArticlePath, $wgUser;
-		$form = "<table style=\"width:100%;\">
-					<tr>
-						<td>".$this->msg('oredict-import-input')->text()."</td>
-						<td></td>
-					</tr>
-					" . OreDictForm::createInputHint('import', 'input') . "
-					<tr>
-						<td colspan=\"2\">
-							<textarea name=\"input\" style=\"width:100%; height: 600px;\"></textarea>
-						</td>
-					</tr>
-					<tr>
-						<td colspan=\"2\">
-							<input type=\"submit\" value=\"".$this->msg("oredict-import-submit")->text()."\">
-							<input type=\"checkbox\" value=\"1\" name=\"update_table\" id=\"update_table\">
-							<label for=\"update_table\">".$this->msg("oredict-import-update")->text()."</label>
-							<span style=\"font-size: x-small;padding: .2em .5em;color: #666;\">
-								".$this->msg("oredict-import-update-hint")->parse()."
-							</span>
-						</td>
-					</tr>
-				</table>";
 
-		$out = Xml::openElement('form', array('method' => 'post', 'action' => str_replace('$1', 'Special:ImportOreDict', $wgArticlePath), 'id' => 'ext-oredict-import-form'))
-			 . Xml::fieldset($this->msg('oredict-import-legend')->text())
-			 . Html::hidden('title', $this->getTitle()->getPrefixedText())
-			 . Html::hidden('token', $wgUser->getEditToken())
-			 . $form
-			 . Xml::closeElement( 'fieldset' )
-			 . Xml::closeElement( 'form' ) . "\n";
+		$fieldset = new OOUI\FieldsetLayout([
+			'label' => $this->msg('oredict-import-legend')->text(),
+			'items' => [
+				new OOUI\HorizontalLayout([
+					'items' => [
+						new OOUI\LabelWidget([
+							'label' => $this->msg('oredict-import-input')->text()
+						])
+					]
+				]),
+				new OOUI\LabelWidget([
+					'label' => new OOUI\HtmlSnippet($this->msg('oredict-import-input-hint')->parse())
+				]),
+				new OOUI\TextInputWidget([
+					'classes' => ['oredict-import-textarea'],
+					'autofocus' => true,
+					'multiline' => true,
+					'rows' => 40,
+					'name' => 'input'
+				]),
+				new OOUI\HorizontalLayout([
+					'items' => [
+						new OOUI\ButtonInputWidget([
+							'type' => 'submit',
+							'label' => $this->msg('oredict-import-submit')->text(),
+							'flags' => ['primary', 'progressive']
+						]),
+						new OOUI\FieldLayout(
+							new OOUI\CheckboxInputWidget([
+								'value' => '1',
+								'name' => 'update_table',
+								'inputId' => 'update_table'
+							]),
+							[
+								'classes' => ['oredict-import-update'],
+								'label' => $this->msg('oredict-import-update')->text(),
+								'align' => 'inline'
+							]
+						),
+						new OOUI\LabelWidget([
+							'classes' => ['oredict-import-update-hint-label'],
+							'label' => new OOUI\HtmlSnippet($this->msg('oredict-import-update-hint')->parse())
+						])
+					]
+				]),
 
-		return $out;
+			]
+		]);
+
+		$form = new OOUI\FormLayout([
+			'method' => 'POST',
+			'action' => str_replace('$1', 'Special:ImportOreDict', $wgArticlePath),
+			'id' => 'ext-oredict-import-form'
+		]);
+		$form->appendContent(
+			$fieldset,
+			new OOUI\HtmlSnippet(
+				Html::hidden('title', $this->getTitle()->getPrefixedText()) .
+				Html::hidden('token', $wgUser->getEditToken())
+			)
+		);
+
+		return new OOUI\PanelLayout([
+			'classes' => ['oredict-importer-wrapper'],
+			'framed' => true,
+			'expanded' => false,
+			'padded' => true,
+			'content' => $form
+		]);
 	}
 
 	/**

--- a/special/OreDictEntryManager.php
+++ b/special/OreDictEntryManager.php
@@ -29,6 +29,7 @@ class OreDictEntryManager extends SpecialPage {
 		$this->checkPermissions();
 
 		$out = $this->getOutput();
+		$out->enableOOUI();
 
 		// Add modules
 		$out->addModules( 'ext.oredict.manager' );
@@ -121,47 +122,143 @@ class OreDictEntryManager extends SpecialPage {
 		global $wgScript;
 		$vEntryId = is_object($opts) ? $opts->entry_id : -1;
 		$vTagName = is_object($opts) ? $opts->tag_name : '';
-		$vTagReadonly = is_object($opts) ? "readonly=\"readonly\"" : '';
+		$vTagReadonly = is_object($opts);
 		$vItemName = is_object($opts) ? $opts->item_name : '';
 		$vModName = is_object($opts) ? $opts->mod_name : '';
 		$vGridParams = is_object($opts) ? $opts->grid_params : '';
-		$msgFieldsetMain = is_object($opts) ? wfMessage('oredict-manager-edit-legend') : wfMessage('oredict-manager-create-legend');
-		$msgSubmitValue = is_object($opts) ? wfMessage('oredict-manager-update') : wfMessage('oredict-manager-create');
-		$form = "<table>";
-		$form .= OreDictForm::createFormRow('manager', 'entry_id', $vEntryId, "text", "readonly=\"readonly\"");
-		$form .= OreDictForm::createFormRow('manager', 'tag_name', $vTagName, "text", $vTagReadonly);
-		$form .= OreDictForm::createFormRow('manager', 'item_name', $vItemName);
-		$form .= OreDictForm::createFormRow('manager', 'mod_name', $vModName);
-		$form .= OreDictForm::createFormRow('manager', 'grid_params', $vGridParams);
-		$form .= "<input type=\"submit\" value=\"".$msgSubmitValue."\">";
-		$form .= "</table>";
+		$msgFieldsetMain = is_object($opts) ? $this->msg('oredict-manager-edit-legend') : $this->msg('oredict-manager-create-legend');
+		$msgSubmitValue = is_object($opts) ? $this->msg('oredict-manager-update') : $this->msg('oredict-manager-create');
 
-		$out = Xml::openElement('form', array('method' => 'get', 'action' => $wgScript, 'id' => 'ext-oredict-manager-form'))
-			 . Xml::fieldset($msgFieldsetMain->text())
-			 . Html::hidden('title', $this->getTitle()->getPrefixedText())
-			 . Html::hidden('token', $this->getUser()->getEditToken())
-			 . Html::hidden('update', 1)
-			 . $form
-			 . Xml::closeElement( 'fieldset' )
-			 . Xml::closeElement( 'form' )
-			 . "\n";
+		$fieldset = new OOUI\FieldsetLayout([
+			'label' => $msgFieldsetMain->text(),
+			'items' => [
+				new OOUI\FieldLayout(
+					new OOUI\TextInputWidget([
+						'type' => 'number',
+						'name' => 'entry_id',
+						'value' => $vEntryId,
+						'readOnly' => true
+					]),
+					[
+						'label' => $this->msg('oredict-manager-entry_id')->text()
+					]
+				),
+				new OOUI\FieldLayout(
+					new OOUI\TextInputWidget([
+						'name' => 'tag_name',
+						'value' => $vTagName,
+						'readOnly' => $vTagReadonly
+					]),
+					[
+						'label' => $this->msg('oredict-manager-tag_name')->text()
+					]
+				),
+				new OOUI\FieldLayout(
+					new OOUI\TextInputWidget([
+						'name' => 'item_name',
+						'value' => $vItemName
+					]),
+					[
+						'label' => $this->msg('oredict-manager-item_name')->text()
+					]
+				),
+				new OOUI\FieldLayout(
+					new OOUI\TextInputWidget([
+						'name' => 'mod_name',
+						'value' => $vModName
+					]),
+					[
+						'label' => $this->msg('oredict-manager-mod_name')->text()
+					]
+				),
+				new OOUI\FieldLayout(
+					new OOUI\TextInputWidget([
+						'name' => 'grid_params',
+						'value' => $vGridParams
+					]),
+					[
+						'label' => $this->msg('oredict-manager-grid_params')->text()
+					]
+				),
+				new OOUI\ButtonInputWidget([
+					'type' => 'submit',
+					'label' => $msgSubmitValue->text(),
+					'flags' => ['primary', 'progressive']
+				])
+			]
+		]);
+		$form = new OOUI\FormLayout([
+			'method' => 'GET',
+			'action' => $wgScript,
+			'id' => 'ext-oredict-manager-form'
+		]);
 
-		return $out;
+		$form->appendContent(
+			$fieldset,
+			new OOUI\HtmlSnippet(
+				Html::hidden('title', $this->getTitle()->getPrefixedText()) .
+				Html::hidden('token', $this->getUser()->getEditToken()) .
+				Html::hidden('update', 1)
+			)
+		);
+
+		return new OOUI\PanelLayout([
+			'classes' => ['entry-manager-wrapper'],
+			'framed' => true,
+			'expanded' => false,
+			'padded' => true,
+			'content' => $form
+		]);
 	}
 
 	private function outputSearchForm() {
 		global $wgScript;
-		$form = "<table>";
-		$form .= OreDictForm::createFormRow('manager-filter', 'entry_id', '', 'number', 'min="1" id="form-entry-id"');
-		$form .= "<tr><td></td><td><input type=\"submit\" value=\"".wfMessage("oredict-manager-submit")."\"><input type=\"button\" value=\"Create new entry\" id=\"form-create-new\"></td></tr>";
-		$form .= "</table>";
+		$fieldset = new OOUI\FieldsetLayout([
+			'label' => $this->msg('oredict-manager-filter-legend')->text(),
+			'items' => [
+				new OOUI\FieldLayout(
+					new OOUI\TextInputWidget([
+						'type' => 'number',
+						'name' => 'entry_id',
+						'value' => '',
+						'min' => '1',
+						'id' => 'form-entry-id',
+						'icon' => 'search'
+					]),
+					[
+						'label' => $this->msg('oredict-manager-filter-entry_id')->text()
+					]
+				),
+				new OOUI\HorizontalLayout([
+					'items' => [
+						new OOUI\ButtonInputWidget([
+							'label' => $this->msg('oredict-manager-submit')->text(),
+							'type' => 'submit'
+						]),
+						new OOUI\ButtonInputWidget([
+							'id' => 'form-create-new',
+							'label' => 'Create new entry' // todo localization
+						])
+					]
+				])
+			]
+		]);
+		$form = new OOUI\FormLayout([
+			'method' => 'GET',
+			'action' => $wgScript,
+			'id' => 'ext-oredict-manager-filter'
+		]);
+		$form->appendContent(
+			$fieldset,
+			new OOUI\HtmlSnippet(Html::hidden('title', $this->getTitle()->getPrefixedText()))
+		);
 
-		$out = Xml::openElement('form', array('method' => 'get', 'action' => $wgScript, 'id' => 'ext-oredict-manager-filter')) .
-			Xml::fieldset($this->msg('oredict-manager-filter-legend')->text()) .
-			Html::hidden('title', $this->getTitle()->getPrefixedText()) .
-			$form .
-			Xml::closeElement( 'fieldset' ) . Xml::closeElement( 'form' ) . "\n";
-
-		return $out;
+		return new OOUI\PanelLayout([
+			'classes' => ['entry-manager-filter-wrapper'],
+			'framed' => true,
+			'expanded' => false,
+			'padded' => true,
+			'content' => $form
+		]);
 	}
 }

--- a/special/OreDictList.php
+++ b/special/OreDictList.php
@@ -29,6 +29,7 @@ class OreDictList extends SpecialPage {
 	public function execute($par) {
 		global $wgQueryPageDefaultLimit;
 		$out = $this->getOutput();
+		$out->enableOOUI();
 
 		$this->setHeaders();
 		$this->outputHeader();
@@ -169,41 +170,85 @@ class OreDictList extends SpecialPage {
 		$out->addModules( 'ext.oredict.list' );
 	}
 
+	const SIZES = [
+		['data' => 20],
+		['data' => 50],
+		['data' => 100],
+		['data' => 250],
+		['data' => 500],
+		['data' => 5000]
+	];
+
 	public function buildForm(FormOptions $opts) {
 		global $wgScript;
-		$optionTags = "";
-		foreach ([20,50,100,250,500,5000] as $lim) {
-			if ($opts->getValue('limit') == $lim) {
-				$optionTags .= "<option selected=\"\" value=\"$lim\">$lim</option>";
-			} else {
-				$optionTags .= "<option value=\"$lim\">$lim</option>";
-			}
-		}
 
-		$form = "<table>";
-		$form .= OreDictForm::createFormRow('list', 'from', $opts->getValue('from'), "number", "min=\"1\"");
-		$form .= OreDictForm::createFormRow('list', 'start', $opts->getValue('start'));
-		$form .= OreDictForm::createFormRow('list', 'tag', $opts->getValue('tag'));
-		$form .= OreDictForm::createFormRow('list', 'mod', $opts->getValue('mod'));
-		$form .= '<tr>
-					<td style="text-align:right">
-						<label for="limit">'.$this->msg('oredict-list-limit').'</label>
-					</td>
-					<td>
-						<select name="limit">'.$optionTags.'</select>
-					</td>
-				  </tr>';
-		$form .= OreDictForm::createSubmitButton('list');
-		$form .= "</table>";
+		$fieldset = new OOUI\FieldsetLayout([
+			'label' => $this->msg('oredict-list-legend')->text(),
+			'items' => [
+				new OOUI\FieldLayout(
+					new OOUI\TextInputWidget([
+						'type' => 'number',
+						'name' => 'from',
+						'value' => $opts->getValue('from'),
+						'min' => '1',
+						'id' => 'from'
+					]),
+					['label' => $this->msg('oredict-list-from')->text()]
+				),
+				new OOUI\FieldLayout(
+					new OOUI\TextInputWidget([
+						'name' => 'start',
+						'value' => $opts->getValue('start'),
+						'id' => 'start'
+					]),
+					['label' => $this->msg('oredict-list-start')->text()]
+				),
+				new OOUI\FieldLayout(
+					new OOUI\TextInputWidget([
+						'name' => 'tag',
+						'value' => $opts->getValue('tag'),
+						'id' => 'tag'
+					]),
+					['label' => $this->msg('oredict-list-tag')->text()]
+				),
+				new OOUI\FieldLayout(
+					new OOUI\TextInputWidget([
+						'name' => 'mod',
+						'value' => $opts->getValue('mod'),
+						'id' => 'mod'
+					]),
+					['label' => $this->msg('oredict-list-mod')->text()]
+				),
+				new OOUI\FieldLayout(
+					new OOUI\DropdownInputWidget([
+						'options' => self::SIZES,
+						'value' => $opts->getValue('limit')
+					]),
+					['label' => $this->msg('oredict-list-limit')->text()]
+				),
+				new OOUI\ButtonInputWidget([
+					'type' => 'submit',
+					'label' => $this->msg('oredict-list-submit')->text(),
+					'flags' => ['primary', 'progressive']
+				])
+			]
+		]);
 
-		$out = Xml::openElement('form', array('method' => 'get', 'action' => $wgScript, 'id' => 'ext-oredict-list-filter'))
-			 . Xml::fieldset($this->msg('oredict-list-legend')->text())
-			 . Html::hidden('title', $this->getTitle()->getPrefixedText())
-			 . $form
-			 . Xml::closeElement( 'fieldset' )
-			 . Xml::closeElement( 'form' )
-			 . "\n";
-
-		return $out;
+		$form = new OOUI\FormLayout([
+			'method' => 'GET',
+			'action' => $wgScript,
+			'id' => 'ext-oredict-list-filter',
+		]);
+		$form->appendContent(
+			$fieldset,
+			new OOUI\HtmlSnippet(Html::hidden('title', $this->getTitle()->getPrefixedText()))
+		);
+		return new OOUI\PanelLayout([
+			'classes' => ['oredictlist-filter-wrapper'],
+			'framed' => true,
+			'expanded' => false,
+			'padded' => true,
+			'content' => $form
+		]);
 	}
 }


### PR DESCRIPTION
This updates our special pages to use the OOjs UI system bundled with MediaWiki as of 1.23. MediaWiki and Gamepedia seem to be moving to this system over time, so we may as well move onto it as well. The new look of the special pages can be seen below.

@retep998 @xbony2 @Alexia 

## OreDictList
![](https://puu.sh/x6L0k/4331229af5.png)

## OreDictEntryManager
![](https://puu.sh/x6Joe/826be93100.png)

## ImportOreDict
![](https://puu.sh/x6PbB/9a910f02d8.png)