### PR TITLE
Update ImportOreDict, OreDictEntryManager (update form only), and OreDictList to use HTMLForm

### DIFF
--- a/css/ext.oredict.import.css
+++ b/css/ext.oredict.import.css
@@ -1,22 +1,9 @@
-.oredict-import-update-hint-label {
-    font-size: x-small;
-    padding-top: 0.5em;
-    color: #666666;
-}
-
 .oredict-import-textarea {
     padding-bottom: 0.5em;
 }
 
 .oredict-import-textarea textarea {
     width: 145.5%;
-}
-
-.oredict-import-update-hint-label {
-    font-size: x-small;
-    padding: .2em .5em;
-    color: #666;
-    display: inline !important;
 }
 
 .oo-ui-checkboxInputWidget {

--- a/css/ext.oredict.manager.css
+++ b/css/ext.oredict.manager.css
@@ -1,3 +1,3 @@
-.entry-manager-wrapper, .entry-manager-filter-wrapper {
+.entry-manager-filter-wrapper {
     width: 50%;
 }

--- a/special/ImportOreDict.php
+++ b/special/ImportOreDict.php
@@ -53,7 +53,7 @@ class ImportOreDict extends SpecialPage {
 		// Process and save POST data
 		if ($_POST) {
 			// XSRF prevention
-			if ( !$this->getUser()->matchEditToken( $this->getRequest()->getVal( 'token' ) ) ) {
+			if ( !$this->getUser()->matchEditToken( $this->getRequest()->getVal( 'wpEditToken' ) ) ) {
 				return;
 			}
 
@@ -154,83 +154,43 @@ class ImportOreDict extends SpecialPage {
 			}
 			$out->addHtml('</tt>');
 		} else {
-			$out->addHtml($this->buildForm());
+			$this->displayForm();
 		}
 	}
 
-	/**
-	 * Build the oredict creation form
-	 *
-	 * @return string
-	 */
+	private function displayForm() {
+		global $wgArticlePath;
 
-	private function buildForm() {
-		global $wgArticlePath, $wgUser;
+		$formDescriptor = [
+		    'input' => [
+		        'type' => 'textarea',
+		        'name' => 'input',
+                'autofocus' => true,
+                'rows' => 40,
+                'cssclass' => 'oredict-import-textarea',
+                'label-message' => 'oredict-import-input',
+                'help-message' => 'oredict-import-input-hint'
+            ],
+            'update_table' => [
+                'type' => 'check',
+                'name' => 'update_table',
+                'id' => 'update_table',
+                'default' => 0,
+                'label-message' => 'oredict-import-update',
+                'help-message' => 'oredict-import-update-hint'
+            ]
+        ];
 
-		$fieldset = new OOUI\FieldsetLayout([
-			'label' => $this->msg('oredict-import-legend')->text(),
-			'items' => [
-				new OOUI\HorizontalLayout([
-					'items' => [
-						new OOUI\LabelWidget([
-							'label' => $this->msg('oredict-import-input')->text()
-						])
-					]
-				]),
-				new OOUI\LabelWidget([
-					'label' => new OOUI\HtmlSnippet($this->msg('oredict-import-input-hint')->parse())
-				]),
-				new OOUI\MultilineTextInputWidget([
-					'classes' => ['oredict-import-textarea'],
-					'autofocus' => true,
-					'rows' => 40,
-					'name' => 'input'
-				]),
-				new OOUI\HorizontalLayout([
-					'items' => [
-						new OOUI\ButtonInputWidget([
-							'type' => 'submit',
-							'label' => $this->msg('oredict-import-submit')->text(),
-							'flags' => ['primary', 'progressive']
-						]),
-						new OOUI\CheckboxInputWidget([
-							'value' => '1',
-							'name' => 'update_table',
-							'inputId' => 'update_table'
-						]),
-						new OOUI\LabelWidget([
-							'label' => $this->msg('oredict-import-update')->text()
-						]),
-						new OOUI\LabelWidget([
-							'classes' => ['oredict-import-update-hint-label'],
-							'label' => new OOUI\HtmlSnippet($this->msg('oredict-import-update-hint')->parse())
-						])
-					]
-				]),
-
-			]
-		]);
-
-		$form = new OOUI\FormLayout([
-			'method' => 'POST',
-			'action' => str_replace('$1', 'Special:ImportOreDict', $wgArticlePath),
-			'id' => 'ext-oredict-import-form'
-		]);
-		$form->appendContent(
-			$fieldset,
-			new OOUI\HtmlSnippet(
-				Html::hidden('title', $this->getTitle()->getPrefixedText()) .
-				Html::hidden('token', $wgUser->getEditToken())
-			)
-		);
-
-		return new OOUI\PanelLayout([
-			'classes' => ['oredict-importer-wrapper'],
-			'framed' => true,
-			'expanded' => false,
-			'padded' => true,
-			'content' => $form
-		]);
+        $htmlForm = HTMLForm::factory('ooui', $formDescriptor, $this->getContext());
+        $htmlForm
+            ->setMethod('post')
+            ->setAction(str_replace('$1', 'Special:ImportOreDict', $wgArticlePath))
+            ->setWrapperLegendMsg('tilesheet-create-legend')
+            ->setId('ext-oredict-import-form')
+            ->setSubmitTextMsg('oredict-import-submit')
+            ->setSubmitProgressive()
+            ->prepareForm()
+            ->displayForm(false);
 	}
 
 	/**

--- a/special/OreDictEntryManager.php
+++ b/special/OreDictEntryManager.php
@@ -94,14 +94,14 @@ class OreDictEntryManager extends SpecialPage {
 
 		if ($results->numRows() == 0 && $opts->getValue('entry_id') != -1 && $opts->getValue('entry_id') != -2) {
 			$out->addWikiText(wfMessage('oredict-manager-fail-norows')->text());
-			// $out->addHtml($this->outputUpdateForm());
+			// $this->>displayUpdateForm();
 		} else if ($opts->getValue('entry_id') == -2) {
 			$out->addWikiText(wfMessage('oredict-manager-fail-insert')->text());
-			$out->addHtml($this->outputUpdateForm());
+			$this->displayUpdateForm();
 		} else if ($results->numRows() == 1) {
-			$out->addHtml($this->outputUpdateForm($results->current()));
+            $this->displayUpdateForm($results->current());
 		} else {
-			$out->addHtml($this->outputUpdateForm());
+            $this->displayUpdateForm();
 		}
 	}
 
@@ -150,111 +150,69 @@ class OreDictEntryManager extends SpecialPage {
 		return OreDict::editEntry($ary, $entryId, $this->getUser());
 	}
 
-	private function outputUpdateForm(stdClass $opts = NULL) {
-		global $wgScript;
+	private function displayUpdateForm(stdClass $opts = NULL) {
 		$vEntryId = is_object($opts) ? $opts->entry_id : -1;
 		$vTagName = is_object($opts) ? $opts->tag_name : '';
 		$vTagReadonly = is_object($opts);
 		$vItemName = is_object($opts) ? $opts->item_name : '';
 		$vModName = is_object($opts) ? $opts->mod_name : '';
 		$vGridParams = is_object($opts) ? $opts->grid_params : '';
-		$msgFieldsetMain = is_object($opts) ? $this->msg('oredict-manager-edit-legend') : $this->msg('oredict-manager-create-legend');
-		$msgSubmitValue = is_object($opts) ? $this->msg('oredict-manager-update') : $this->msg('oredict-manager-create');
+		$msgFieldsetMain = is_object($opts) ? 'oredict-manager-edit-legend' : 'oredict-manager-create-legend';
+		$msgSubmitValue = is_object($opts) ? 'oredict-manager-update' : 'oredict-manager-create';
 
-		$fieldset = new OOUI\FieldsetLayout([
-			'label' => $msgFieldsetMain->text(),
-			'items' => [
-				new OOUI\FieldLayout(
-					new OOUI\TextInputWidget([
-						'type' => 'number',
-						'name' => 'entry_id',
-						'value' => $vEntryId,
-						'readOnly' => true
-					]),
-					[
-						'label' => $this->msg('oredict-manager-entry_id')->text()
-					]
-				),
-				new OOUI\FieldLayout(
-					new OOUI\TextInputWidget([
-						'name' => 'tag_name',
-						'value' => $vTagName,
-						'readOnly' => $vTagReadonly
-					]),
-					[
-						'label' => $this->msg('oredict-manager-tag_name')->text()
-					]
-				),
-				new OOUI\FieldLayout(
-					new OOUI\TextInputWidget([
-						'name' => 'item_name',
-						'value' => $vItemName
-					]),
-					[
-						'label' => $this->msg('oredict-manager-item_name')->text()
-					]
-				),
-				new OOUI\FieldLayout(
-					new OOUI\TextInputWidget([
-						'name' => 'mod_name',
-						'value' => $vModName
-					]),
-					[
-						'label' => $this->msg('oredict-manager-mod_name')->text()
-					]
-				),
-				new OOUI\FieldLayout(
-					new OOUI\TextInputWidget([
-						'name' => 'grid_params',
-						'value' => $vGridParams
-					]),
-					[
-						'label' => $this->msg('oredict-manager-grid_params')->text()
-					]
-				),
-				new OOUI\HorizontalLayout([
-					'items' => [
-						new OOUI\ButtonInputWidget([
-							'type' => 'submit',
-							'label' => $msgSubmitValue->text(),
-							'flags' => ['primary', 'progressive'],
-							'name' => 'update',
-							'value' => 1
-						]),
-						new OOUI\ButtonInputWidget([
-							'type' => 'submit',
-							'label' => $this->msg('oredict-manager-entry_del')->text(),
-							'flags' => ['destructive'],
-							'icon' => 'remove',
-							'name' => 'delete',
-							'value' => 1,
-							'disabled' => $vEntryId == -1
-						])
-					]
-				])
-			]
-		]);
-		$form = new OOUI\FormLayout([
-			'method' => 'GET',
-			'action' => $wgScript,
-			'id' => 'ext-oredict-manager-form'
-		]);
-
-		$form->appendContent(
-			$fieldset,
-			new OOUI\HtmlSnippet(
-				Html::hidden('title', $this->getTitle()->getPrefixedText()) .
-				Html::hidden('token', $this->getUser()->getEditToken())
-			)
-		);
-
-		return new OOUI\PanelLayout([
-			'classes' => ['entry-manager-wrapper'],
-			'framed' => true,
-			'expanded' => false,
-			'padded' => true,
-			'content' => $form
-		]);
+		$formDescriptor = [
+		    'entry_id' => [
+		        'type' => 'int',
+                'name' => 'entry_id',
+                'default' => $vEntryId,
+                'readonly' => true,
+                'label-message' => 'oredict-manager-entry_id'
+            ],
+            'tag_name' => [
+                'type' => 'text',
+                'name' => 'tag_name',
+                'default' => $vTagName,
+                'readonly' => $vTagReadonly,
+                'label-message' => 'oredict-manager-tag_name'
+            ],
+            'item_name' => [
+                'type' => 'text',
+                'name' => 'item_name',
+                'default' => $vItemName,
+                'label-message' => 'oredict-manager-item_name'
+            ],
+            'mod_name' => [
+                'type' => 'text',
+                'name' => 'mod_name',
+                'default' => $vModName,
+                'label-message' => 'oredict-manager-mod_name'
+            ],
+            'grid_params' => [
+                'type' => 'text',
+                'name' => 'grid_params',
+                'default' => $vGridParams,
+                'label-message' => 'oredict-manager-grid_params'
+            ]
+        ];
+		$htmlForm = HTMLForm::factory('ooui', $formDescriptor, $this->getContext());
+		$htmlForm
+            ->addButton([
+                'name' => 'delete',
+                'value' => 1,
+                'label-message' => 'oredict-manager-entry_del',
+                'flags' => ['destructive'],
+                'attribs' => ['disabled' => $vEntryId == -1],
+                'iconElement' => 'remove'
+            ])
+            ->addHIddenField('token', $this->getUser()->getEditToken())
+            ->setMethod('get')
+            ->addHiddenField('update', 1)
+            ->setWrapperLegendMsg($msgFieldsetMain)
+            ->setId('ext-oredict-manager-form')
+            ->setSubmitTextMsg($msgSubmitValue)
+            ->setSubmitProgressive()
+            ->prepareForm()
+            ->displayForm(false);
 	}
 
 	private function outputSearchForm() {

--- a/special/OreDictList.php
+++ b/special/OreDictList.php
@@ -169,7 +169,7 @@ class OreDictList extends SpecialPage {
 		}
 		$pageSelection = '<div style="text-align:center;" class="plainlinks">'.$prevPage.' | '.$nextPage.'</div>';
 
-		$out->addHtml($this->buildForm($opts));
+		$this->displayForm($opts);
 		if ($maxRows == 0) {
 			$out->addWikiText(wfMessage('oredict-list-display-none')->text());
 		} else {
@@ -186,86 +186,62 @@ class OreDictList extends SpecialPage {
 		$out->addModules( 'ext.oredict.list' );
 	}
 
-	const SIZES = [
-		['data' => 20],
-		['data' => 50],
-		['data' => 100],
-		['data' => 250],
-		['data' => 500],
-		['data' => 5000]
-	];
+	public function displayForm(FormOptions $opts) {
+		$lang = $this->getLanguage();
+		$formDescriptor = [
+		    'from' => [
+		        'type' => 'int',
+                'name' => 'from',
+                'default' => $opts->getValue('from'),
+                'min' => 1,
+                'id' => 'from',
+                'label-message' => 'oredict-list-from'
+            ],
+            'start' => [
+                'type' => 'text',
+                'name' => 'start',
+                'default' => $opts->getValue('start'),
+                'id' => 'start',
+                'label-message' => 'oredict-list-start'
+            ],
+            'tag' => [
+                'type' => 'text',
+                'name' => 'tag',
+                'default' => $opts->getValue('tag'),
+                'id' => 'tag',
+                'label-message' => 'oredict-list-tag'
+            ],
+            'mod' => [
+                'type' => 'text',
+                'name' => 'mod',
+                'default' => $opts->getValue('mod'),
+                'id' => 'mod',
+                'label-message' => 'oredict-list-mod'
+            ],
+            'limit' => [
+                'type' => 'limitselect',
+                'name' => 'limit',
+                'label-message' => 'oredict-list-limit',
+                'options' => [
+                    $lang->formatNum(20) => 20,
+                    $lang->formatNum(50) => 50,
+                    $lang->formatNum(100) => 100,
+                    $lang->formatNum(250) => 250,
+                    $lang->formatNum(500) => 500,
+                    $lang->formatNum(5000) => 5000
+                ],
+                'default' => $opts->getValue('limit')
+            ]
+        ];
 
-	public function buildForm(FormOptions $opts) {
-		global $wgScript;
-
-		$fieldset = new OOUI\FieldsetLayout([
-			'label' => $this->msg('oredict-list-legend')->text(),
-			'items' => [
-				new OOUI\FieldLayout(
-					new OOUI\TextInputWidget([
-						'type' => 'number',
-						'name' => 'from',
-						'value' => $opts->getValue('from'),
-						'min' => '1',
-						'id' => 'from'
-					]),
-					['label' => $this->msg('oredict-list-from')->text()]
-				),
-				new OOUI\FieldLayout(
-					new OOUI\TextInputWidget([
-						'name' => 'start',
-						'value' => $opts->getValue('start'),
-						'id' => 'start'
-					]),
-					['label' => $this->msg('oredict-list-start')->text()]
-				),
-				new OOUI\FieldLayout(
-					new OOUI\TextInputWidget([
-						'name' => 'tag',
-						'value' => $opts->getValue('tag'),
-						'id' => 'tag'
-					]),
-					['label' => $this->msg('oredict-list-tag')->text()]
-				),
-				new OOUI\FieldLayout(
-					new OOUI\TextInputWidget([
-						'name' => 'mod',
-						'value' => $opts->getValue('mod'),
-						'id' => 'mod'
-					]),
-					['label' => $this->msg('oredict-list-mod')->text()]
-				),
-				new OOUI\FieldLayout(
-					new OOUI\DropdownInputWidget([
-						'options' => self::SIZES,
-						'value' => $opts->getValue('limit'),
-						'name' => 'limit'
-					]),
-					['label' => $this->msg('oredict-list-limit')->text()]
-				),
-				new OOUI\ButtonInputWidget([
-					'type' => 'submit',
-					'label' => $this->msg('oredict-list-submit')->text(),
-					'flags' => ['primary', 'progressive']
-				])
-			]
-		]);
-
-		$form = new OOUI\FormLayout([
-			'method' => 'GET',
-			'action' => $wgScript,
-			'id' => 'ext-oredict-list-filter',
-		]);
-		$form->appendContent(
-			$fieldset,
-			new OOUI\HtmlSnippet(Html::hidden('title', $this->getTitle()->getPrefixedText()))
-		);
-		return new OOUI\PanelLayout([
-			'classes' => ['oredictlist-filter-wrapper'],
-			'framed' => true,
-			'expanded' => false,
-			'padded' => true,
-			'content' => $form
-		]);
+		$htmlForm = HTMLForm::factory('ooui', $formDescriptor, $this->getContext());
+		$htmlForm
+            ->setMethod('get')
+            ->setWrapperLegendMsg('oredict-list-legend')
+            ->setId('ext-oredict-list-filter')
+            ->setSubmitTextMsg('oredict-list-submit')
+            ->setSubmitProgressive()
+            ->prepareForm()
+            ->displayForm(false);
 	}
 }


### PR DESCRIPTION
Update our special pages to use HTMLForm where possible. Currently, the only places where it is not possible to use HTMLForm is the search fields.

## ImportOreDict (zoomed out to fit the whole form)
![Screen Shot 2019-12-17 at 3 49 08 PM](https://user-images.githubusercontent.com/4176124/71043866-cea87400-20e4-11ea-960e-33a1cb008915.png)

## OreDictEntryManager
### Update
![Screen Shot 2019-12-17 at 3 50 46 PM](https://user-images.githubusercontent.com/4176124/71043931-04e5f380-20e5-11ea-9b37-46dde8a61d7e.png)

### Create
![Screen Shot 2019-12-17 at 3 49 42 PM](https://user-images.githubusercontent.com/4176124/71043954-19c28700-20e5-11ea-983a-179401563d6a.png)

## OreDictList
![Screen Shot 2019-12-17 at 3 50 08 PM](https://user-images.githubusercontent.com/4176124/71043920-f7306e00-20e4-11ea-902c-a6ef8fab80ca.png)