### PR TITLE
Bump to 3.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 This changelog only shows recent version history, because of the lack of documentation from the former maintainers. The very first changelog (1.0.2) is likely incomplete.
 
 ## Version 3
+### 3.3.6
+* Add support to set limit of entries returned
+* Replace deprecated calls with their updated equivalents
+
 ### 3.3.5
 * Remove unused OreDictForm class.
 * Update ImportOreDict, OreDictEntryManager (update form only), and OreDictList to use HTMLFormg (#74).

--- a/OreDict.body.php
+++ b/OreDict.body.php
@@ -22,11 +22,12 @@ class OreDict{
 	 *
 	 * @param string $itemName
 	 * @param string $itemMod
+	 * @param int $limit
 	 */
-	public function __construct($itemName, $itemMod = '') {
+	public function __construct(string $itemName, string $itemMod, int $limit) {
 		$this->mItemName = $itemName;
-		$this->mOutputLimit = 20;
 		$this->mItemMod = $itemMod;
+		$this->mOutputLimit = $limit;
 	}
 
 	/**
@@ -78,7 +79,7 @@ class OreDict{
 	 * @return bool
 	 */
 	public function exec($byTag = false, $noFallback = false) {
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = wfGetDB(DB_REPLICA);
 
 		// Vars
 		$itemModEscaped = $dbr->addQuotes($this->mItemMod);
@@ -192,7 +193,7 @@ class OreDict{
 	 * @return bool
 	 */
 	static public function entryExists($item, $tag, $mod) {
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = wfGetDB(DB_REPLICA);
 
 		$result = $dbr->select(
 			'ext_oredict_items',
@@ -212,7 +213,7 @@ class OreDict{
 	 * @return mixed		See checkExists.
 	 */
 	static public function checkExistsByID($id) {
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = wfGetDB(DB_REPLICA);
 		$res = $dbr->select(
 			'ext_oredict_items',
 			array(
@@ -414,8 +415,8 @@ class OreDict{
 	}
 
 	/**
-	 * @param $row ?		The row to get the data from.
-	 * @return array		An array containing the tag, mod, item, and grid params for use throughout the API.
+	 * @param ? $row The row to get the data from.
+	 * @return array An array containing the tag, mod, item, and grid params for use throughout the API.
 	 */
 	static public function getArrayFromRow($row) {
 		return array(

--- a/OreDict.hooks.php
+++ b/OreDict.hooks.php
@@ -97,16 +97,8 @@ class OreDictHooks {
 		// Create grids
 		$outs = array();
 		foreach ($items as $options) {
-			// Set mod
-			$mod = '';
-			if (isset($options['mod'])) {
-				$mod = $options['mod'];
-			}
-
 			// Call OreDict
-			$dict = new OreDict($options[1], $mod);
-			$dict->exec(isset($options['tag']), isset($options['no-fallback']));
-			$outs[] = $dict->runHooks(self::BuildParamString($options));
+			$outs[] = self::runHooks($options);
 		}
 
 		$ret = "";
@@ -134,15 +126,8 @@ class OreDictHooks {
 		}
 		$options = OreDictHooks::ExtractOptions($opts);
 
-		// Set mod
-		$mod = '';
-		if (isset($options['mod'])) {
-			$mod = $options['mod'];
-		}
 		// Call OreDict
-		$dict = new OreDict($options[1], $mod);
-		$dict->exec(isset($options['tag']), isset($options['no-fallback']));
-		return $dict->runHooks(self::BuildParamString($options));
+		return self::runHooks($options);
 	}
 
 	/**
@@ -212,5 +197,31 @@ class OreDictHooks {
 		$editPage->editFormTextAfterWarn .= $errors->output();
 
 		return true;
+	}
+
+	private static function getOptions($options) {
+		// Set mod
+		$mod = '';
+		if (isset($options['mod'])) {
+			$mod = $options['mod'];
+		}
+
+		// Set limit
+		if (isset($options['limit'])) {
+			$limit = $options['limit'];
+		}
+		if (!isset($limit) || $limit <= 0) {
+			$limit = 20;
+		}
+
+		return array($mod, $limit);
+	}
+
+	private static function runHooks($options) {
+		list ($mod, $limit) = self::getOptions($options);
+
+		$dict = new OreDict($options[1], $mod, $limit);
+		$dict->exec(isset($options['tag']), isset($options['no-fallback']));
+		return $dict->runHooks(self::BuildParamString($options));
 	}
 }

--- a/api/OreDictQueryEntryApi.php
+++ b/api/OreDictQueryEntryApi.php
@@ -25,7 +25,7 @@ class OreDictQueryEntryApi extends ApiQueryBase {
 
     public function execute() {
         $ids = $this->getParameter('ids');
-        $dbr = wfGetDB(DB_SLAVE);
+        $dbr = wfGetDB(DB_REPLICA);
         $ret = array();
 
         foreach ($ids as $id) {

--- a/api/OreDictQuerySearchApi.php
+++ b/api/OreDictQuerySearchApi.php
@@ -52,7 +52,7 @@ class OreDictQuerySearchApi extends ApiQueryBase {
         $name = $this->getParameter('name');
         $limit = $this->getParameter('limit');
         $from = $this->getParameter('from');
-        $dbr = wfGetDB(DB_SLAVE);
+        $dbr = wfGetDB(DB_REPLICA);
 
         $conditions = array(
             "entry_id >= $from"

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "OreDict",
-	"version": "3.3.5",
+	"version": "3.3.6",
 	"author": "[http://ftb.gamepedia.com/User:Jinbobo Jinbobo], Telshin, [http://ftb.gamepedia.com/User:Retep998 Retep998], [http://ftb.gamepedia.com/User:TheSatanicSanta Eli Foster], noahm, applehat",
 	"url": "http://help.gamepedia.com/Extension:OreDict",
 	"descriptionmsg": "oredict-desc",

--- a/special/ImportOreDict.php
+++ b/special/ImportOreDict.php
@@ -57,7 +57,7 @@ class ImportOreDict extends SpecialPage {
 				return;
 			}
 
-			$out->addHtml('<tt>');
+			$out->addHtml('<samp>');
 			$dbw = wfGetDB(DB_MASTER);
 
 			$input = explode("\n", trim($opts->getValue('input')));
@@ -152,7 +152,7 @@ class ImportOreDict extends SpecialPage {
 
 				$out->addHTML($this->returnMessage(true, wfMessage('oredict-import-success-new', $result)->text()));
 			}
-			$out->addHtml('</tt>');
+			$out->addHtml('</samp>');
 		} else {
 			$this->displayForm();
 		}
@@ -188,7 +188,6 @@ class ImportOreDict extends SpecialPage {
             ->setWrapperLegendMsg('tilesheet-create-legend')
             ->setId('ext-oredict-import-form')
             ->setSubmitTextMsg('oredict-import-submit')
-            ->setSubmitProgressive()
             ->prepareForm()
             ->displayForm(false);
 	}

--- a/special/OreDictEntryManager.php
+++ b/special/OreDictEntryManager.php
@@ -74,11 +74,11 @@ class OreDictEntryManager extends SpecialPage {
 						break;
 					}
 					case 1: {
-						$out->addWikiText($this->msg('oredict-manager-fail-general')->text());
+						$out->addWikiTextAsInterface($this->msg('oredict-manager-fail-general')->text());
 						break;
 					}
 					case 2: {
-						$out->addWikiText($this->msg('oredict-import-fail-nochange')->text());
+						$out->addWikiTextAsInterface($this->msg('oredict-import-fail-nochange')->text());
 						break;
 					}
 				}
@@ -89,14 +89,14 @@ class OreDictEntryManager extends SpecialPage {
 		}
 
 		// Load data
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = wfGetDB(DB_REPLICA);
 		$results = $dbr->select('ext_oredict_items','*',array('entry_id' => $opts->getValue('entry_id')));
 
 		if ($results->numRows() == 0 && $opts->getValue('entry_id') != -1 && $opts->getValue('entry_id') != -2) {
-			$out->addWikiText(wfMessage('oredict-manager-fail-norows')->text());
+			$out->addWikiTextAsInterface(wfMessage('oredict-manager-fail-norows')->text());
 			// $this->>displayUpdateForm();
 		} else if ($opts->getValue('entry_id') == -2) {
-			$out->addWikiText(wfMessage('oredict-manager-fail-insert')->text());
+			$out->addWikiTextAsInterface(wfMessage('oredict-manager-fail-insert')->text());
 			$this->displayUpdateForm();
 		} else if ($results->numRows() == 1) {
             $this->displayUpdateForm($results->current());
@@ -210,7 +210,6 @@ class OreDictEntryManager extends SpecialPage {
             ->setWrapperLegendMsg($msgFieldsetMain)
             ->setId('ext-oredict-manager-form')
             ->setSubmitTextMsg($msgSubmitValue)
-            ->setSubmitProgressive()
             ->prepareForm()
             ->displayForm(false);
 	}
@@ -257,7 +256,7 @@ class OreDictEntryManager extends SpecialPage {
 		]);
 		$form->appendContent(
 			$fieldset,
-			new OOUI\HtmlSnippet(Html::hidden('title', $this->getTitle()->getPrefixedText()))
+			new OOUI\HtmlSnippet(Html::hidden('title', $this->getPageTitle()->getPrefixedText()))
 		);
 
 		return new OOUI\PanelLayout([

--- a/special/OreDictList.php
+++ b/special/OreDictList.php
@@ -62,7 +62,7 @@ class OreDictList extends SpecialPage {
 		$page = intval($opts->getValue('page'));
 
 		// Load data
-		$dbr = wfGetDB(DB_SLAVE);
+		$dbr = wfGetDB(DB_REPLICA);
 		$results =  $dbr->select(
 			'ext_oredict_items',
 			'COUNT(`entry_id`) AS row_count',
@@ -85,7 +85,7 @@ class OreDictList extends SpecialPage {
 		}
 
 		$begin = $page * $limit;
-		$end = min($begin + $limit, $maxRows);
+		// $end = min($begin + $limit, $maxRows);
 		$order = $start == '' ? 'entry_id ASC' : 'item_name ASC';
 		$results = $dbr->select(
 			'ext_oredict_items',
@@ -171,16 +171,16 @@ class OreDictList extends SpecialPage {
 
 		$this->displayForm($opts);
 		if ($maxRows == 0) {
-			$out->addWikiText(wfMessage('oredict-list-display-none')->text());
+			$out->addWikiTextAsInterface(wfMessage('oredict-list-display-none')->text());
 		} else {
 			// We are currently at the end from the iteration earlier in the function, so we have to go back to get the
 			// first row's entry ID.
 			$results->rewind();
 			$firstID = $results->current()->entry_id;
-			$out->addWikiText(wfMessage('oredict-list-displaying', $firstID, $lastID, $maxRows)->text());
+			$out->addWikiTextAsInterface(wfMessage('oredict-list-displaying', $firstID, $lastID, $maxRows)->text());
 		}
-		$out->addWikiText(" $pageSelection\n");
-		$out->addWikitext($table);
+		$out->addWikiTextAsInterface(" $pageSelection\n");
+		$out->addWikiTextAsInterface($table);
 
 		// Add modules
 		$out->addModules( 'ext.oredict.list' );
@@ -240,7 +240,6 @@ class OreDictList extends SpecialPage {
             ->setWrapperLegendMsg('oredict-list-legend')
             ->setId('ext-oredict-list-filter')
             ->setSubmitTextMsg('oredict-list-submit')
-            ->setSubmitProgressive()
             ->prepareForm()
             ->displayForm(false);
 	}


### PR DESCRIPTION
Simple PR that does two things:
* Adds support to set limit of entries returned
* Replaces deprecated calls with their updated equivalents

The first change was requested by retep on discord. Simple enough.
The second change was to ensure compatibility on later versions of MW when Gamepedia/Fandom eventually decides to update. I found that trying to use 1.35.1 resulted in errors and fixing them was trivial. Any deprecated calls were replaced with their updated equivalents, and tested and confirmed to work. The rest of the random changes in this PR were also related to deprecation.