### PR TITLE
Add imports for namespaced classes

### DIFF
--- a/OreDict.body.php
+++ b/OreDict.body.php
@@ -1,4 +1,6 @@
 <?php
+
+use MediaWiki\Title\Title;
 use Wikimedia\Rdbms\ILoadBalancer;
 use MediaWiki\MediaWikiServices;
 
@@ -126,7 +128,7 @@ class OreDict{
 				if (!empty($tagNameList)) {
 					$where['tag_name'] = $tagNameList;
 				}
-				
+
 				$result = $dbr->newSelectQueryBuilder()
 					->select('*')
 					->from('ext_oredict_items')
@@ -204,7 +206,7 @@ class OreDict{
 			])
 			->caller(__METHOD__)
 			->fetchField();
-			
+
 		return $numEntries > 0;
 	}
 
@@ -297,7 +299,7 @@ class OreDict{
 		} catch (Exception $e) {
 			return false;
 		}
-		
+
 		$lastInsert = intval($dbw->newSelectQueryBuilder()
 			->select('entry_id')
 			->from('ext_oredict_items')
@@ -358,7 +360,7 @@ class OreDict{
 		if (!self::isStrValid($tag) || !self::isStrValid($item) || !self::isStrValid($mod)) {
 			return 1;
 		}
-		
+
 		try {
 			$dbw->newUpdateQueryBuilder()
 				->update('ext_oredict_items')

--- a/OreDict.hooks.php
+++ b/OreDict.hooks.php
@@ -1,4 +1,6 @@
 <?php
+
+use MediaWiki\EditPage\EditPage;
 use MediaWiki\Hook\ParserFirstCallInitHook;
 use MediaWiki\Hook\EditPage__showEditForm_initialHook;
 

--- a/extension.json
+++ b/extension.json
@@ -5,6 +5,9 @@
 	"url": "http://help.gamepedia.com/Extension:OreDict",
 	"descriptionmsg": "oredict-desc",
 	"type": "parserhook",
+	"requires": {
+		"MediaWiki": ">= 1.40.0"
+	},
 	"license-name": "MIT",
 	"AvailableRights": [
 		"editoredict",

--- a/special/ImportOreDict.php
+++ b/special/ImportOreDict.php
@@ -9,6 +9,8 @@
  * @license
  */
 
+use MediaWiki\Html\FormOptions;
+use MediaWiki\Title\Title;
 use Wikimedia\Rdbms\ILoadBalancer;
 
 class ImportOreDict extends SpecialPage {
@@ -96,7 +98,7 @@ class ImportOreDict extends SpecialPage {
 								'mod_name' => $modName
 							))
 							->fetchRow();
-						
+
 						$tag = $tagName;
 						$fItem = $itemName;
 						$mod = $modName;

--- a/special/OreDictEntryManager.php
+++ b/special/OreDictEntryManager.php
@@ -1,4 +1,7 @@
 <?php
+
+use MediaWiki\Html\FormOptions;
+use MediaWiki\Html\Html;
 use Wikimedia\Rdbms\ILoadBalancer;
 
 /**
@@ -97,7 +100,7 @@ class OreDictEntryManager extends SpecialPage {
 			->from('ext_oredict_items')
 			->where(array('entry_id' => $opts->getValue('entry_id')))
 			->fetchResultSet();
-		
+
 		// todo: refactor
 		if ($results->numRows() == 0 && $opts->getValue('entry_id') != -1 && $opts->getValue('entry_id') != -2) {
 			$out->addWikiTextAsInterface(wfMessage('oredict-manager-fail-norows')->text());

--- a/special/OreDictList.php
+++ b/special/OreDictList.php
@@ -1,4 +1,6 @@
 <?php
+
+use MediaWiki\Html\FormOptions;
 use Wikimedia\Rdbms\ILoadBalancer;
 use MediaWiki\Permissions\PermissionManager;
 
@@ -79,9 +81,9 @@ class OreDictList extends SpecialPage {
 			->caller(__METHOD__)
 			->limit($limit)
 			->fetchField();
-		
+
 		if (!$maxRows) return;
-		
+
 		$begin = $page * $limit;
 		$end = min($begin + $limit, $maxRows);
 		$order = $start == '' ? 'entry_id ASC' : 'item_name ASC';


### PR DESCRIPTION
The associated non-namespaced class aliases are no longer present, breaking the extension on MW >= 1.44. Raise the MW requirement to 1.40 accordingly.
#88